### PR TITLE
Fix error: getPrinterJob is not a static field 

### DIFF
--- a/src/clj_paper_print/core.clj
+++ b/src/clj_paper_print/core.clj
@@ -107,7 +107,7 @@
   "A macro to create a PrintrJob object."
   ([-symbol]
    `(do
-      (def ~-symbol PrinterJob/getPrinterJob)
+      (def ~-symbol (. PrinterJob getPrinterJob))
    ~-symbol))
   ([-symbol config]
    `(let [c# (atom-checker ~config)]

--- a/test/clj_paper_print/core_test.clj
+++ b/test/clj_paper_print/core_test.clj
@@ -1,9 +1,14 @@
 (ns clj-paper-print.core-test
   (:require [clojure.test :refer :all]
+            [clj-paper-print.core :refer :all]
             [clojure.spec.alpha :as s])
   (:import [javax.print.attribute.standard MediaSizeName MediaSize Media]
            [javax.print.attribute Size2DSyntax]))
 
+(deftest prinjob-can-be-defined 
+  (testing "It can be defined"
+    (defprintjob some-name)
+  ))
 
 ;; TODO add tests of core
 ;; (deftest a-test


### PR DESCRIPTION
In Windows with ubuntu and Java11 the exception was thrown when defining a print job exception. It has been reproduced and described in the red commit message.
The fix has been done in the green commit, it consist on a syntax refactor.
Please consider to squash, commits in the branch are for a narrative/communicational purpose.